### PR TITLE
add method setConnectTimeout

### DIFF
--- a/src/FuseSource/Stomp/Stomp.php
+++ b/src/FuseSource/Stomp/Stomp.php
@@ -542,6 +542,17 @@ class Stomp
         $this->_read_timeout_seconds = $seconds;
         $this->_read_timeout_milliseconds = $milliseconds;
     }
+	
+    /**
+     * Set timeout to wait for connection to MQ
+     *
+     * @param int $seconds  Seconds to attempt for a connection
+     * 
+     */
+    public function setConnectTimeout($seconds)
+    {
+        $this->_connect_timeout_seconds = $seconds;
+    }
 
     /**
      * Read response frame from server


### PR DESCRIPTION
We need to have to set connectionTimeout because 60 is too high for production environnement.
When MQ is down, a connection timeout at 60 seconds overload our server
